### PR TITLE
Prevent Null Exception when closing

### DIFF
--- a/src/com/sqide/sdk/SquirrelSdkUtil.java
+++ b/src/com/sqide/sdk/SquirrelSdkUtil.java
@@ -184,7 +184,7 @@ public class SquirrelSdkUtil {
 
         if (!binDirectory.exists()) {
             File[] files = new File(path).listFiles();
-            for (File file : files) {
+            for (File file : files != null ? files : new File[0]) {
                 if (file.isDirectory()) {
                     String versionDir = file.getAbsolutePath();
                     binDirectory = new File(versionDir, "bin");


### PR DESCRIPTION
When you try to save or close with a bad or invalid path, an exception pops up and it's this line that's affected.